### PR TITLE
🔧 Enable Args in context scripts

### DIFF
--- a/prompts/add_meta_prompt.txt
+++ b/prompts/add_meta_prompt.txt
@@ -42,9 +42,9 @@ context_scripts:
   key_name_2: "another shell command"
 
 # The main prompt template sent to the LLM. (Required)
-# It can use variables from context_scripts like {{ Context.key_name_1 }}.
+# It can use variables from context_scripts like {% raw %} {{ Context.key_name_1 }} {% endraw %}.
 prompt: |
   This is the main prompt text.
-  The output of the first script is: {{ Context.key_name_1 }}
+  The output of the first script is: {% raw %} {{ Context.key_name_1 }} {% endraw %}
 
 Begin the conversation now.


### PR DESCRIPTION
# What does this PR do?

  This PR adds support for using Args variables within context scripts, allowing dynamic script generation based on user-provided arguments. It also fixes the meta prompt documentation to properly escape
  Jinja2 template syntax.

  ## Details

  - Context scripts are now rendered through Tera before execution, enabling {{ Args.variable }} substitution
  - Added intermediate rendering step: Args → render scripts → execute scripts → render main prompt
  - Fixed meta prompt template to use {% raw %} blocks, preventing Jinja2 syntax from being interpreted prematurely
  - Created HashMap to store rendered scripts before passing to execute_context_scripts()

  ## Highlights
```
  // Render the context scripts through Tera to substitute Args variables
  let mut tera = Tera::default();
  let mut rendered_scripts = HashMap::new();
  for (name, script_template) in &goal.config.context_scripts {
      tera.add_raw_template(name, script_template)
          .with_context(|| format!("Failed to add context script template '{}'", name))?;
      let rendered_script = tera
          .render(name, &context)
          .map_err(|e| anyhow::anyhow!("Failed to render context script '{}': {}", name, e))?;
      rendered_scripts.insert(name.clone(), rendered_script);
  }
```
  // Execute the rendered context scripts
  let script_outputs = runner::execute_context_scripts(&rendered_scripts)?;